### PR TITLE
Updated an error in the header of the helpline page

### DIFF
--- a/app/uk/gov/hmrc/helplinefrontend/views/helplinesByService/Helpline.scala.html
+++ b/app/uk/gov/hmrc/helplinefrontend/views/helplinesByService/Helpline.scala.html
@@ -40,7 +40,7 @@
     rws
 }
 
-@layout(pageTitle = s"${messages(s"helplines-search.vat.h1")} ${messages("title.suffix")}") {
+@layout(pageTitle = s"${messages(s"helplines-search.${helpdesk}.h1")} ${messages("title.suffix")}") {
     @preHeading(heading.replaceAll("_", " "))
     @h1(messages(s"helplines-search.${helpdesk}.h1"))
     @summaryList(rows = rows, classes = "govuk-summary-list--no-border")


### PR DESCRIPTION
Rach found that the tab headers weren't updating when the page changed. This has not been retified.